### PR TITLE
[Edwin Pavlovsky] Storing registration info in Firebase

### DIFF
--- a/adrmobileapp/App.tsx
+++ b/adrmobileapp/App.tsx
@@ -79,7 +79,7 @@ function Section({children, title}: SectionProps): React.JSX.Element {
 export type RootStackParamList = {
   HomeScreen: undefined;
   RegistrationScreen: undefined;
-  SecondRegistrationScreen: undefined;
+  SecondRegistrationScreen: {name: string; email: string};
   BookMain: {book: Book};
   BookQuiz: {book: Book};
   BookInfo: {book: Book};

--- a/adrmobileapp/pages/login.tsx
+++ b/adrmobileapp/pages/login.tsx
@@ -78,7 +78,12 @@ export function Login(_props: LoginProps): React.JSX.Element {
         </View>
         {/* Login Button */}
         <TouchableOpacity
-          style={styles.loginButtonContainer}
+          style={[
+            styles.loginButtonContainer,
+            {
+              backgroundColor: isDarkMode ? Colors.white : Colors.black,
+            },
+          ]}
           onPress={async () => {
             try {
               await handleLogin();
@@ -93,7 +98,7 @@ export function Login(_props: LoginProps): React.JSX.Element {
             style={[
               styles.loginButtonText,
               {
-                color: isDarkMode ? Colors.white : Colors.black,
+                color: isDarkMode ? Colors.black : Colors.white,
               },
             ]}>
             Login
@@ -155,7 +160,6 @@ const styles = StyleSheet.create({
     fontSize: 13,
   },
   loginButtonContainer: {
-    backgroundColor: '#000000',
     padding: 15,
     borderRadius: 15,
     alignItems: 'center',

--- a/adrmobileapp/pages/register.tsx
+++ b/adrmobileapp/pages/register.tsx
@@ -12,8 +12,6 @@ import {
 import {getAuth, createUserWithEmailAndPassword} from 'firebase/auth';
 import {NavigationProp} from '@react-navigation/native';
 import {RootStackParamList} from '../App';
-import {initializeFirebase} from '../config/firebase';
-import {collection, getFirestore} from 'firebase/firestore';
 
 type RegisterProps = {
   navigation: NavigationProp<RootStackParamList>;
@@ -26,22 +24,6 @@ export function RegistrationScreen(_props: RegisterProps): React.JSX.Element {
   const [feedbacktext, setFeedbackText] = useState('');
 
   const auth = getAuth();
-
-  initializeFirebase();
-  const firestore = getFirestore();
-
-  function writeUser() {
-    const usersCollection = collection(firestore, 'users');
-    // User data object with the provided fields
-    const userData = {
-      name: name,
-      email: email,
-      userType: 'Parent',
-      schoolId: schoolId,
-      schoolDistrictId: schoolDistrictId
-    };
-
-  }
 
   const handleRegister = () => {
     return new Promise<void>((resolve, reject) => {
@@ -101,7 +83,10 @@ export function RegistrationScreen(_props: RegisterProps): React.JSX.Element {
             try {
               await handleRegister();
               // Iif handleRegister doesn't throw error, navigate to next screen
-              _props.navigation.navigate('SecondRegistrationScreen');
+              _props.navigation.navigate('SecondRegistrationScreen', {
+                name: name,
+                email: email,
+              });
             } catch (error) {
               const errorMessage = error.message;
               setFeedbackText(errorMessage);

--- a/adrmobileapp/pages/register.tsx
+++ b/adrmobileapp/pages/register.tsx
@@ -12,17 +12,36 @@ import {
 import {getAuth, createUserWithEmailAndPassword} from 'firebase/auth';
 import {NavigationProp} from '@react-navigation/native';
 import {RootStackParamList} from '../App';
+import {initializeFirebase} from '../config/firebase';
+import {collection, getFirestore} from 'firebase/firestore';
 
 type RegisterProps = {
   navigation: NavigationProp<RootStackParamList>;
 };
 
 export function RegistrationScreen(_props: RegisterProps): React.JSX.Element {
+  const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [feedbacktext, setFeedbackText] = useState('');
 
   const auth = getAuth();
+
+  initializeFirebase();
+  const firestore = getFirestore();
+
+  function writeUser() {
+    const usersCollection = collection(firestore, 'users');
+    // User data object with the provided fields
+    const userData = {
+      name: name,
+      email: email,
+      userType: 'Parent',
+      schoolId: schoolId,
+      schoolDistrictId: schoolDistrictId
+    };
+
+  }
 
   const handleRegister = () => {
     return new Promise<void>((resolve, reject) => {
@@ -51,7 +70,7 @@ export function RegistrationScreen(_props: RegisterProps): React.JSX.Element {
           placeholderTextColor="gray"
           autoCapitalize="none" // Prevents auto-capitalization of the first character
           returnKeyType="done"
-          //onChangeText={text => setEmail(text)}
+          onChangeText={text => setName(text)}
         />
         {/* Email Input */}
         <TextInput

--- a/adrmobileapp/pages/register2.tsx
+++ b/adrmobileapp/pages/register2.tsx
@@ -8,22 +8,60 @@ import {
   TouchableOpacity,
   ScrollView,
 } from 'react-native';
-import {NavigationProp} from '@react-navigation/native';
+import {RouteProp} from '@react-navigation/native';
 import {Picker} from '@react-native-picker/picker';
 import {RootStackParamList} from '../App';
+import {initializeFirebase} from '../config/firebase';
+import {addDoc, collection, getFirestore} from 'firebase/firestore';
+import {StackNavigationProp} from '@react-navigation/stack';
+
+type routeProp = RouteProp<RootStackParamList, 'SecondRegistrationScreen'>;
+type navProp = StackNavigationProp<
+  RootStackParamList,
+  'SecondRegistrationScreen'
+>;
 
 type Register2Props = {
-  navigation: NavigationProp<RootStackParamList>;
+  navigation: navProp;
+  route: routeProp; // Route prop to access parameters
 };
 
 export function SecondRegistrationScreen(
-  _props: Register2Props,
+  props: Register2Props,
 ): React.JSX.Element {
+  const {name, email} = props.route.params; // Access name and email from route parameters
+
   const [selectedDistrict, setSelectedDistrict] = useState('');
   const [showDistrictPicker, setShowDistrictPicker] = useState(false);
   const [selectedSchool, setSelectedSchool] = useState('');
   const [showSchoolPicker, setShowSchoolPicker] = useState(false);
   const [numChildren, setNumChildren] = useState('');
+
+  initializeFirebase();
+  const firestore = getFirestore();
+
+  // schoolId and schoolDistrictId are populated in the next page
+  async function writeUser() {
+    const usersCollection = collection(firestore, 'users');
+
+    // userData Document Object
+    const userData = {
+      name: name,
+      email: email,
+      userType: 'Parent',
+      schoolId: selectedSchool,
+      schoolDistrictId: selectedDistrict,
+      numChildren: numChildren,
+    };
+
+    try {
+      // Adds a new document with an automatically generated ID
+      const userRef = await addDoc(usersCollection, userData);
+      console.log('Document written with ID: ', userRef.id);
+    } catch (e) {
+      console.error('Error adding document: ', e);
+    }
+  }
 
   // Checking if num children input is an integer >= 0
   const handleNumChildrenChange = (text: string) => {
@@ -100,7 +138,14 @@ export function SecondRegistrationScreen(
           {/* Login Button */}
           <TouchableOpacity
             style={styles.finishButtonContainer}
-            onPress={() => _props.navigation.navigate('HomeScreen')}>
+            onPress={async () => {
+              try {
+                await writeUser();
+                props.navigation.navigate('HomeScreen');
+              } catch (error) {
+                console.error('Error finishing registration: ', error);
+              }
+            }}>
             <Text style={styles.finishButtonText}>Finish</Text>
           </TouchableOpacity>
         </View>


### PR DESCRIPTION
Changes made for within this PR:

- Stored the user registration info in Firebase (test example picture attached to this PR)
  * Information stored in one Document:  `name`, `email`, `userType` (which is always `Parent` for now), `schoolID`, `schoolDistrictID`, and `numChildren`
  * Currently, the `schoolID` and `schoolDistrictID` correspond to the strings of the school or school district name that the user chooses since the `schoolDistricts` and `schools` collections (as specified in the DB Plan) have not been created
  * There is no explicit `userID` field but a unique ID for each document is automatically created by Firebase each time a new user registers
  * To do this, the first registration screen (`register.tsx`) passes the name and email fields chosen by the user during registration along to the second registration screen (`register2.tsx`) where once the user finishes inputting data onto this screen, that info is then stored in Firebase. Data is not updated in Firebase in the first registration screen in case a user incorrectly registers (i.e. password is not long enough) on the first registration screen, useless data isn't stored and thus only stored once a fully correct registration occurs.
 - Minor style changes
   * Made the login button coloring dynamic based on if the user has dark mode activated (or not)
<img width="1211" alt="registration info in Firebase" src="https://github.com/Hack4Impact-UMD/ADR-Mobile/assets/66393792/0b2ba686-b2bb-4462-93df-6357cbadd07c">